### PR TITLE
Fix for OH crashes

### DIFF
--- a/barebones.ohf
+++ b/barebones.ohf
@@ -37,10 +37,6 @@
 
 
 
-##f$prefold##
-
-
-
 ##f$chat##
 
 
@@ -62,12 +58,13 @@
 0
 
 
-##f$ini_function_on_my_turn##
-isfinalanswer ? me_st_dec_f$dlldecision : 0
-
-
 ##f$ini_function_on_heartbeat##
 0
+
+
+##f$ini_function_on_my_turn##
+//isfinalanswer ? me_st_dec_f$dlldecision : 0
+
 
 
 ##f$test##
@@ -86,19 +83,20 @@ A6o KTo K8o K5o QJo Q8o Q3o JTo J5o T6o 92o 87o 85o 84o 62o 43o
 
 
 ##f$preflop##
-me_re_dec
+//me_re_dec
 
 
 ##f$flop##
-me_re_dec
+//me_re_dec
 
 
 ##f$turn##
-me_re_dec
+//me_re_dec
 
 
 ##f$river##
-me_re_dec
+//me_re_dec
+
 
 
 ##f$dlldecision##

--- a/src/COpponentModeling.cpp
+++ b/src/COpponentModeling.cpp
@@ -277,3 +277,40 @@ int COpponentModeling::ModelOpponent(int chair_ndx, int betround, ePlayerAction 
 
 	return 0;
 }
+
+int COpponentModeling::ModelOpponents()
+{
+	int chair_ndx, betround = g_symbols->get_betround();
+
+	for (chair_ndx = 0; chair_ndx < g_symbols->get_nchairs(); chair_ndx++)
+	{
+		if (g_extract_actions->_current_hand_info._player_actions[chair_ndx]._b_was_in_game)
+		{
+			if (ePreflop == betround)
+			{
+				//opp modeling - move
+				double pt_vpip = g_symbols->_pt.get_pt_vpip(chair_ndx);
+				if (pt_vpip < 0)
+					pt_vpip = 0.4;
+
+				double pt_pfr = g_symbols->_pt.get_pt_pfr(chair_ndx);
+				if (pt_pfr < 0)
+					pt_pfr = 0.15;
+
+				ePreflopAction preflop_action = g_extract_actions->_current_hand_info._player_actions[chair_ndx].GetPreflopAction(false);
+				if (preflop_action == actionCall)
+					PrwSetPreflopTopList(chair_ndx, pt_vpip, 1024);
+				else if (preflop_action >= actionBetRaise)
+					PrwSetPreflopTopList(chair_ndx, pt_pfr, 1024);
+			}
+			else
+			{
+				ePostflopAction postflop_action = g_extract_actions->_current_hand_info._player_actions[chair_ndx].GetPostflopAction(betround);
+				if (postflop_action >= actionCall)
+					Prw1326Postflop(chair_ndx, 1024);
+			}
+		}
+	}
+
+	return 0;
+}

--- a/src/COpponentModeling.h
+++ b/src/COpponentModeling.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <string>
+//#include <string>
 #include <set>
 #include <vector>
 
@@ -88,11 +88,12 @@ public:
 	void PrwSetPreflopMiddleList(int player_ndx, double play_pct, double exclude_pct, int weight);
 	void PrwSetPreflopTopList(int player_ndx, double play_pct, int weight);
 	int  ModelOpponent(int chair_ndx,int betround, ePlayerAction action);
+	int  ModelOpponents();
 
 	void init(int listnum, int weight);
 	void HandReset();
 	void PrwLogHandlist(int handnumber, int userchair, int betround, int log_param);
-	void CreateDir(std::string dirname);
+	void CreateDir(char *dirname);
 };
 
 //extern COpponentModeling* g_opponent_modeling;

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -43,7 +43,7 @@ CLogging* g_log = nullptr;
 CSymbols* g_symbols = nullptr;
 CExtractActions* g_extract_actions;
 CBoardTexture* g_board_texture = nullptr;
-//COpponentModeling* g_opponent_modeling = nullptr;
+COpponentModeling* g_opponent_modeling = nullptr;
 CDecision* g_decision = nullptr;
 
 bool is_busy = false;
@@ -57,10 +57,10 @@ void DLLOnUnLoad()
 	if (g_decision)
 		delete g_decision;
 
-	/*
+	
 	if (g_opponent_modeling)
 		delete g_opponent_modeling;
-	*/
+	
 
 	if (g_board_texture)
 		delete g_board_texture;
@@ -80,10 +80,10 @@ void __stdcall DLLUpdateOnNewFormula()
 	if (g_decision)
 		delete g_decision;
 
-	/*
+	
 	if(g_opponent_modeling)
 		delete g_opponent_modeling;
-	*/
+	
 
 	if (g_board_texture)
 		delete g_board_texture;
@@ -102,7 +102,7 @@ void __stdcall DLLUpdateOnNewFormula()
 	g_symbols = new CSymbols();
 	g_extract_actions = new CExtractActions();
 	g_board_texture = new CBoardTexture();
-	//g_opponent_modeling = new COpponentModeling();
+	g_opponent_modeling = new COpponentModeling();
 	g_decision = new CDecision();
 }
 
@@ -113,7 +113,7 @@ void __stdcall DLLUpdateOnConnection()
 void __stdcall DLLUpdateOnHandreset() 
 {
 	g_extract_actions->ExtractActionsReset();
-	//g_opponent_modeling->HandReset();
+	g_opponent_modeling->HandReset();
 }
 
 void __stdcall DLLUpdateOnNewRound() 
@@ -122,6 +122,15 @@ void __stdcall DLLUpdateOnNewRound()
 
 void __stdcall DLLUpdateOnMyTurn() 
 {
+	is_busy = true;
+	g_symbols->UpdateOHSymbols();
+	g_board_texture->CalcTexture();
+	g_extract_actions->ExtractActions();
+	g_opponent_modeling->ModelOpponents();
+
+	GetSymbol("cmd$recalc");
+	g_decision->Decision();
+	is_busy = false;
 }
 
 void __stdcall DLLUpdateOnHeartbeat() 
@@ -176,7 +185,7 @@ DLL_IMPLEMENTS double __stdcall ProcessQuery(const char* pquery)
 		g_symbols->UpdateOHSymbols();
 		g_board_texture->CalcTexture();
 		g_extract_actions->ExtractActions();
-		//g_opponent_modeling->ModelOpponents();
+		g_opponent_modeling->ModelOpponents();
 
 		GetSymbol("cmd$recalc");
 		double decision = g_decision->Decision();


### PR DESCRIPTION
Code correction for OH crashes time by time caused by use of std::string instead of char * like Trish mentioned on this thread: http://www.maxinmontreal.com/forums/viewtopic.php?f=124&t=22379&hilit=crash#p165218

I've bypassed also dll$decision calls in ohf and write directly Decision() code on DLLUpdateOnMyTurn() method.